### PR TITLE
start: Remove start-scoped config.json and runtime.json references

### DIFF
--- a/runtime.md
+++ b/runtime.md
@@ -44,7 +44,6 @@ $ echo $?
 ### start
 
 Start a container from a bundle directory.
-It operates by default on the `config.json` and `runtime.json` in the current directory.
 
 * *Options*
   * *`--id <ID>`* Set the container ID when creating or joining a container.


### PR DESCRIPTION
The reference landed in the initial 3f0aafb7 (Add initial command line
spec, 2015-09-02) in the operations section.  In f3a1c088 (Shift
config.json and runtime.json into the 'start' section, 2015-09-15)
they moved to the 'start' command section, because other commands
don't need them.  But we talk about them in start's options section
since 9d97d395 (Add --config and --runtime options, 2015-09-14), so
there's no need for this command-scoped reference.

Signed-off-by: W. Trevor King wking@tremily.us
