### PR TITLE
Use imperative phrasing for command summaries

### DIFF
--- a/runtime.md
+++ b/runtime.md
@@ -43,7 +43,7 @@ $ echo $?
 
 ### start
 
-Starts a container from a bundle directory.
+Start a container from a bundle directory.
 It operates by default on the `config.json` and `runtime.json` in the current directory.
 
 * *Options*


### PR DESCRIPTION
This makes everything consistent with the version command's:

> Print the runtime version and exit.

And follows the practice recommended by Python's [PEP 257](https://www.python.org/dev/peps/pep-0257/#one-line-docstrings):

> The docstring is a phrase ending in a period. It prescribes the
> function or method's effect as a command ("Do this", "Return that"),
> not as a description; e.g. don't write "Returns the pathname ...".
