### PR TITLE
start: Change --config and --runtime to --bundle

### DIFF
--- a/runtime.md
+++ b/runtime.md
@@ -51,8 +51,7 @@ Start a container from a bundle directory.
 * *Options*
   * *`--id <ID>`* Set the container ID when creating or joining a container.
     If not set, the runtime is free to pick any ID that is not already in use.
-  * *`--config <PATH>`* Override `config.json` with an alternative path.  The path may not support seeking (e.g. `/dev/fd/3`).
-  * *`--runtime <PATH>`* Override `runtime.json` with an alternative path.  The path may not support seeking (e.g. `/dev/fd/3`).
+  * *`--bundle <PATH>`* Override the path to the bundle directory (defaults to the current working directory).
 * *Standard streams:* The runtime must attach its standard streams directly to the application process without inspection.
 * *Environment variables*
   * *`LISTEN_FDS`:* The number of file descriptors passed.


### PR DESCRIPTION
Personally I prefer [a single config file](https://groups.google.com/a/opencontainers.org/forum/#!topic/dev/0QbyJDM9fWY).  I want folks to be
able to pipe their config into the `funC start` command (e.g. via a
`/dev/fd/3` pseudo-filesystem path, opencontainers/runc#202), and I
have a [working example](https://github.com/wking/ccon/tree/8ab5b535b5eca1a62e12b5e865735e24f1e1666d#configuration) that supports this without difficulty.
But since opencontainers/runc#373 landed on 2015-11-16, runC has
replaced their `--config-file` and `--runtime-file` flags with
`--bundle`, and the current goal of this repository is “keeping as
much similarity with the existing runC command-line as possible”
(ffdd70467), not “makes sense to Trevor” ;).
