### PR TITLE
runtime: Minor style cleanup (drop sh highlighting and add example headers)

### DIFF
--- a/runtime.md
+++ b/runtime.md
@@ -36,7 +36,8 @@ Print the runtime version and exit.
 * *Exit code:* The runtime MUST exit with zero.
 
 Example:
-```sh
+
+```
 $ funC version
 funC 1.0.0
 Built for x86_64-pc-linux-gnu
@@ -59,7 +60,8 @@ Start a container from a bundle directory.
 * *Exit code:* The runtime MUST exit with the application process's exit code.
 
 Example:
-```sh
+
+```
 # in a bundle directory with a process that echos "hello" and exits 42
 $ funC start --id hello-1
 hello

--- a/runtime.md
+++ b/runtime.md
@@ -35,7 +35,7 @@ Print the runtime version and exit.
   * *stderr:* The runtime MAY print diagnostic messages to stderr, and the format for those lines is not specified in this document.
 * *Exit code:* The runtime MUST exit with zero.
 
-Example:
+#### Example
 
 ```
 $ funC version
@@ -59,7 +59,7 @@ Start a container from a bundle directory.
     For example, `LISTEN_FDS=2` would mean that the runtime MUST pass file descriptors 3 and 4 to the application process (in addition to the [standard streams][standard-streams]) to support [socket activation][systemd-listen-fds].
 * *Exit code:* The runtime MUST exit with the application process's exit code.
 
-Example:
+#### Example
 
 ```
 # in a bundle directory with a process that echos "hello" and exits 42


### PR DESCRIPTION
Details in the commit messages.
