### PR TITLE
runtime: Add a 'state' command

### DIFF
--- a/runtime.md
+++ b/runtime.md
@@ -70,6 +70,38 @@ $ echo $?
 42
 ```
 
+### state
+
+Request the container state.
+
+* *Arguments*
+  * *`<ID>`* The container whose state is being requested.
+* *Standard streams:*
+  * *stdin:* The runtime MUST NOT attempt to read from its stdin.
+  * *stdout:* The runtime MUST print the state JSON to its stdout.
+  * *stderr:* The runtime MAY print diagnostic messages to stderr, and the format for those lines is not specified in this document.
+* *Exit code:* Zero if the state was successfully written to stdout and non-zero on errors.
+
+#### Example
+
+```
+# in a bundle directory with a process that sleeps for several seconds
+$ funC start --id sleeper-1 &
+$ funC state sleeper-1
+{
+  "ociVersion": "1.0.0-rc1",
+  "id": "sleeper-1",
+  "status": "running",
+  "pid": 4422,
+  "bundlePath": "/containers/sleeper",
+  "annotations" {
+    "myKey": "myValue"
+  }
+}
+$ echo $?
+0
+```
+
 [posix-encoding]: http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap06.html#tag_06_02
 [posix-lang]: http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html#tag_08_02
 [posix-locale-encoding]: http://www.unicode.org/reports/tr35/#Bundle_vs_Item_Lookup


### PR DESCRIPTION
Partially catch up with opencontainers/runtime-spec@7117ede7 (Expand on the definition of our ops, 2015-10-13, opencontainers/runtime-spec#225, v0.4.0).  The state example is adapted [from the current release](https://github.com/opencontainers/runtime-spec/blob/v1.0.0-rc1/runtime.md#state), but we defer the actual definition of that JSON to runtime-spec.  The UTF-8 requirement extends [runtime-spec's configuration JSON requirement](https://github.com/opencontainers/runtime-spec/blob/v1.0.0-rc1/glossary.md#json) to the output state.

This PR builds on #15, so that should be reviewed first.
